### PR TITLE
c2000: remove c2000 specific handling of enums

### DIFF
--- a/pymavlink/generator/mavgen_c.py
+++ b/pymavlink/generator/mavgen_c.py
@@ -638,20 +638,6 @@ def generate_one(basename, xml):
             else:
                 f.putname = f.const_value
 
-    # Handle (badly) enums with a value that is >16bit signed integer
-    if xml.c2000_protocol:
-        enums_removed = False
-        for enum in xml.enum:
-            if enum.highest_value > 32767:
-                for entry in enum.entry[:]:
-                    if int(entry.value) > 32767:
-                        print("WARNING: Removing ENUM %s=%i" % (entry.name, entry.value))
-                        entry.name = "//" + entry.name
-                        enums_removed = True
-        if enums_removed:
-            print("WARNING: ENUM values larger than 2^15 (signed int) are not supported by the C2000 architecture")
-
-
     generate_mavlink_h(directory, xml)
     generate_version_h(directory, xml)
     generate_main_h(directory, xml)


### PR DESCRIPTION
This hack doesn't seem to be required with the current version of the C2000 compiler (v6.4.2) in use by the solo-gimbal project.
