### PR TITLE
gopro: revamp to support full range of hero3/4 msgs

### DIFF
--- a/message_definitions/v1.0/ardupilotmega.xml
+++ b/message_definitions/v1.0/ardupilotmega.xml
@@ -299,6 +299,7 @@
       </entry>
     </enum>
     <enum name="GOPRO_HEARTBEAT_FLAGS">
+      <!-- each entry is a mask to test a bit in GOPRO_HEARTBEAT_STATUS.flags -->
       <entry name="GOPRO_FLAG_RECORDING" value="1">
         <description>GoPro is currently recording</description>
       </entry>


### PR DESCRIPTION
tasks:
- [x] add status field to `GOPRO_GET_RESPONSE`
- [x] increase payload size for `GOPRO_SET_REQUEST` and `GOPRO_GET_RESPONSE`
- [x] determine if we want to add fields to `GOPRO_HEARTBEAT` (charging status, other?)
- [x] normalize gopro enums to be supersets of both hero 3/4 values

supersedes #6 

cc @Gussy, @arthurbenemann, @eliao, @rgcottrell, @igor-nap, @jschall 
