### PR TITLE
Modifices udp recvfrom to accept MAX_LEN UDP packets.

### DIFF
--- a/pymavlink/mavutil.py
+++ b/pymavlink/mavutil.py
@@ -815,7 +815,7 @@ class mavudp(mavfile):
 
     def recv(self,n=None):
         try:
-            data, self.last_address = self.port.recvfrom(300)
+            data, self.last_address = self.port.recvfrom(65535)
         except socket.error as e:
             if e.errno in [ errno.EAGAIN, errno.EWOULDBLOCK, errno.ECONNREFUSED ]:
                 return ""


### PR DESCRIPTION
This is needed for any external code that uses the mavlink-solo branch.

We now use UDP aggregation, we need to fix the bug of udp packet size truncating possible large packets.
